### PR TITLE
Fixes for someone doing changes in assert :(

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -165,9 +165,10 @@ public:
 
     void SetSecretBytes(const unsigned char vch[32]) {
         BIGNUM *bn;
-	bn = BN_new();
-        assert(BN_bin2bn(vch, 32, bn));
-        assert(EC_KEY_regenerate_key(pkey, bn));
+        bn = BN_bin2bn(vch, 32, NULL);
+        assert(bn);
+        int size = EC_KEY_regenerate_key(pkey, bn);
+        assert(size);
         BN_clear_free(bn);
     }
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -37,7 +37,7 @@ const std::string CLIENT_NAME("LiteDoge");
 #define GIT_ARCHIVE 1
 #ifdef GIT_ARCHIVE
 #    define GIT_COMMIT_ID ""
-#    define GIT_COMMIT_DATE "$Format:%cD"
+#    define GIT_COMMIT_DATE __DATE__
 #endif
 
 #define BUILD_DESC_FROM_COMMIT(maj,min,rev,build,commit) \

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -1709,7 +1709,8 @@ bool CWallet::CreateTransaction(const vector<pair<CScript, int64_t> >& vecSend, 
 
                         // Reserve a new key pair from key pool
                         CPubKey vchPubKey;
-                        assert(reservekey.GetReservedKey(vchPubKey)); // should never fail, as we just unlocked
+                        bool reserved = reservekey.GetReservedKey(vchPubKey);
+                        assert(reserved); // should never fail, as we just unlocked
 
                         scriptChange.SetDestination(vchPubKey.GetID());
                     }


### PR DESCRIPTION
assert is not supposed to be used with code that has side effects. Some compilers when in release mode replace assert with void(0) which is a no-operation. This can cause lost funds when a change address is generated and not saved because the assert method removed the save.