### PR TITLE
Proof of work Reenable and Rewards Hard Fork

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1040,6 +1040,7 @@ public:
     {
         nFlags |= BLOCK_PROOF_OF_STAKE;
     }
+  
     // ppcoin: entropy bit for stake modifier if chosen by modifier
     unsigned int GetStakeEntropyBit(unsigned int nHeight) const
       {


### PR DESCRIPTION
Enable Proof of work rewards again at block 4000000 hard fork, enable DNS seed, fix constraint to tx fee outputs, Seeded nodes.