### PR TITLE
Referencing local leveldb

### DIFF
--- a/src/txdb-leveldb.h
+++ b/src/txdb-leveldb.h
@@ -10,8 +10,8 @@
 #include "main.h"
 #include "db.h"
 #include "bignum.h"
-#include <leveldb/include/leveldb/write_batch.h>
-#include <leveldb/include/leveldb/db.h>
+#include "leveldb/include/leveldb/write_batch.h"
+#include "leveldb/include/leveldb/db.h"
 #include "key.h"
 #include "script.h"
 #include "base58.h"


### PR DESCRIPTION
Those two should reference the local leveldb, I wasn't able to build for Windows, it complains.